### PR TITLE
Update Dockerfile with configurable registry

### DIFF
--- a/deploy/build/Dockerfile
+++ b/deploy/build/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.18-alpine3.16 AS builder
+ARG REGISTRY=docker.io
+FROM ${REGISTRY}/golang:1.18-alpine3.16 AS builder
 RUN set -eux && sed -i 's/dl-cdn.alpinelinux.org/mirrors.ustc.edu.cn/g' /etc/apk/repositories
 
 ARG APP_RELATIVE_PATH
@@ -11,7 +12,7 @@ RUN export GOPROXY=https://goproxy.cn,direct && go mod tidy && go build -ldflags
 RUN mv config /data/app/bin/
 
 
-FROM alpine:3.16
+FROM ${REGISTRY}/alpine:3.16
 RUN set -eux && sed -i 's/dl-cdn.alpinelinux.org/mirrors.ustc.edu.cn/g' /etc/apk/repositories
 
 


### PR DESCRIPTION
add support for custom registry in order to accelerate docker build. 

developer can use it like following
```bash
docker build -f deploy/build/Dockerfile --build-arg APP_RELATIVE_PATH=./cmd/server --build-arg REGISTRY=your registry
```