### PR TITLE
fix: make bootstrap for docker-compose

### DIFF
--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -11,15 +11,15 @@ services:
       - MYSQL_ROOT_PASSWORD=123456
       - MYSQL_ROOT_HOST=%
       - MYSQL_DATABASE=user
-    volumes:
-      - ./data/mysql/user:/var/lib/mysql
-      - ./conf/mysql/conf.d:/etc/mysql/conf.d
+    # volumes:
+    #   - ./data/mysql/user:/var/lib/mysql
+    #   - ./conf/mysql/conf.d:/etc/mysql/conf.d
   cache-redis:
     image: redis:6-alpine
     hostname: cache-redis
-    volumes:
-      - ./data/redis/cache/:/data
-      - ./conf/redis/cache/redis.conf:/etc/redis/redis.conf
+    # volumes:
+    #   - ./data/redis/cache/:/data
+    #   - ./conf/redis/cache/redis.conf:/etc/redis/redis.conf
     ports:
       - 6350:6379
     command: ["redis-server","/etc/redis/redis.conf"]


### PR DESCRIPTION
Error:
```bash
make bootstrap
......
nunu run ./cmd/server
Nunu run ./cmd/server.
Watch excludeDir .git,.idea,tmp,vendor
Watch includeExt go,html,yaml,yml,toml,ini,json,xml,tpl,tmpl
Error: open deploy/docker-compose/data/mysql/user/#innodb_redo: permission denied
```


Fix:  with this commit to do

clean error env
```bash
nunu-layout-advanced/ $ cd deploy/docker-compose
nunu-layout-advanced/deploy/docker-compose $ docker-compose down -v
[+] Running 3/3
 ✔ Container user-db                       Removed                                                                                                                    1.3s 
 ✔ Container docker-compose-cache-redis-1  Removed                                                                                                                    0.0s 
 ✔ Network docker-compose_default          Removed 
nunu-layout-advanced/deploy/docker-compose $ sudo rm -rf conf data
nunu-layout-advanced/deploy/docker-compose $ cd -
nunu-layout-advanced/ $ 
```

retry bootstrap
```bash
nunu-layout-advanced/ $ make bootstrap 
cd ./deploy/docker-compose && docker compose up -d && cd ../../
WARN[0000] nunu-layout-advanced/deploy/docker-compose/docker-compose.yml: `version` is obsolete 
[+] Running 3/3
 ✔ Network docker-compose_default          Created                                                                                                                    0.0s 
 ✔ Container user-db                       Started                                                                                                                    0.5s 
 ✔ Container docker-compose-cache-redis-1  Started                                                                                                                    0.5s 
go run ./cmd/migration
load conf file: config/local.yml

2024/05/09 11:25:10 /home/dev/.cache/.go-global/pkg/mod/github.com/glebarez/sqlite@v1.11.0/migrator.go:32
[0.211ms] [rows:-] SELECT count(*) FROM sqlite_master WHERE type='table' AND name="users"

2024/05/09 11:25:10 /home/dev/.cache/.go-global/pkg/mod/github.com/glebarez/sqlite@v1.11.0/migrator.go:117
[0.084ms] [rows:2] SELECT sql FROM sqlite_master WHERE type IN ("table","index") AND tbl_name = "users" AND sql IS NOT NULL order by type = "table" desc

2024/05/09 11:25:10 /home/dev/.cache/.go-global/pkg/mod/github.com/glebarez/sqlite@v1.11.0/migrator.go:125
[0.027ms] [rows:-] SELECT * FROM `users` LIMIT 1

2024/05/09 11:25:10 /home/dev/.cache/.go-global/pkg/mod/github.com/glebarez/sqlite@v1.11.0/migrator.go:293
[0.020ms] [rows:-] SELECT count(*) FROM sqlite_master WHERE type = "index" AND tbl_name = "users" AND name = "idx_users_deleted_at"
2024-05-09 11:25:10.004307025   info   /nunu-layout-advanced/internal/server/migration.go:28 AutoMigrate success

nunu run ./cmd/server
Nunu run ./cmd/server.
Watch excludeDir .git,.idea,tmp,vendor
Watch includeExt go,html,yaml,yml,toml,ini,json,xml,tpl,tmpl
load conf file: config/local.yml
[GIN-debug] [WARNING] Creating an Engine instance with the Logger and Recovery middleware already attached.

[GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
 - using env:   export GIN_MODE=release
 - using code:  gin.SetMode(gin.ReleaseMode)

[GIN-debug] GET    /swagger/*any             --> github.com/swaggo/gin-swagger.CustomWrapHandler.func1 (3 handlers)
[GIN-debug] GET    /                         --> github.com/go-nunu/nunu-layout-advanced/internal/server.NewHTTPServer.func1 (6 handlers)
[GIN-debug] POST   /v1/register              --> github.com/go-nunu/nunu-layout-advanced/internal/handler.(*UserHandler).Register-fm (6 handlers)
[GIN-debug] POST   /v1/login                 --> github.com/go-nunu/nunu-layout-advanced/internal/handler.(*UserHandler).Login-fm (6 handlers)
[GIN-debug] GET    /v1/user                  --> github.com/go-nunu/nunu-layout-advanced/internal/handler.(*UserHandler).GetProfile-fm (7 handlers)
[GIN-debug] PUT    /v1/user                  --> github.com/go-nunu/nunu-layout-advanced/internal/handler.(*UserHandler).UpdateProfile-fm (7 handlers)
2024-05-09 11:25:10.564837703   info    /home/dev/Projects/nunu-layout-advanced/cmd/server/main.go:41   server start    {"host": "http://127.0.0.1:8000"}
2024-05-09 11:25:10.564917404   info    /home/dev/Projects/nunu-layout-advanced/cmd/server/main.go:42   docs addr       {"addr": "http://127.0.0.1:8000/swagger/index.html"}
running...
```